### PR TITLE
Fix: Configure Config Server for local repo and add personal-service …

### DIFF
--- a/api-config-server/src/main/resources/application.yml
+++ b/api-config-server/src/main/resources/application.yml
@@ -4,11 +4,16 @@ spring:
   cloud:
     config:
       server:
-        git:
-          uri: git@github.com:MartinMSalas/config-server-personal-admin.git
-          private-key: file:/home/m/.ssh/id_rsa
-          default-label: master
-          ignore-local-ssh-settings: false
+        native:
+          search-locations: file:./config-repo/ # Apunta al config-repo local
+          # La configuración de Git anterior se elimina/comenta
+          # git:
+          #   uri: git@github.com:MartinMSalas/config-server-personal-admin.git
+          #   private-key: file:/home/m/.ssh/id_rsa
+          #   default-label: master
+          #   ignore-local-ssh-settings: false
+  profiles:
+    active: native # Asegurarse de que el perfil native esté activo
 
 server:
   port: 8888
@@ -17,15 +22,18 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info
+        include: health,info,env,configprops # Exponer más endpoints para depuración
   info:
     env:
       enabled: true
+  endpoint:
+    health:
+      show-details: always
 
 info:
   app:
     name: api-config-server
-    description: API Config Server
+    description: API Config Server (Native Backend)
     version: 1.0.0
 
 eureka:
@@ -33,7 +41,10 @@ eureka:
     instance-id: MMSTechnology-Personal-Admin:${spring.application.name}:${server.port}
     statusPageUrlPath: http://localhost:8888/actuator/info
     healthCheckUrlPath: http://localhost:8888/actuator/health
+    # Preferir la IP para el registro en Eureka si hay problemas con hostname
+    # prefer-ip-address: true
   client:
     register-with-eureka: true
+    fetch-registry: true # Necesario para que el config server sepa de otros servicios si es necesario
     serviceUrl:
       defaultZone: http://localhost:8761/eureka/

--- a/config-repo/personal-service.yml
+++ b/config-repo/personal-service.yml
@@ -1,0 +1,45 @@
+server:
+  port: 7070 # Puerto específico para personal-service desde config-server
+
+personal:
+  greeting: "Hola desde la configuración remota para Personal Service!"
+  instance:
+    id: "${spring.application.name}:${random.uuid}"
+
+# Ejemplo de cómo se podrían heredar y usar propiedades de application.yml
+# Si global.message está en application.yml, estará disponible aquí también.
+# Si se redefine aquí, esta tomará precedencia.
+# global:
+#   message: "Mensaje global, posiblemente modificado por personal-service.yml"
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*" # Exponer todos los actuadores para personal-service para fácil depuración
+  endpoint:
+    health:
+      show-details: always
+    info: # Para mostrar la info de git si estuviera activo, o custom info
+      enabled: true
+
+info:
+  app:
+    name: "\${spring.application.name}" # Usar el nombre de la aplicación
+    description: "Configuración específica para Personal Service cargada desde Config Server"
+    instanceId: "\${personal.instance.id}"
+    remoteConfigProperty: "\${personal.greeting}"
+    globalMessageFromRemote: "\${global.message:Global message not found}" # Muestra global.message o un default
+
+# Para asegurar que personal-service se registra en Eureka
+eureka:
+  client:
+    register-with-eureka: true
+    fetch-registry: true
+    serviceUrl:
+      defaultZone: http://localhost:8761/eureka/ # Asegurar que esto esté aquí o en application.yml
+  instance:
+    # prefer-ip-address: true # Considerar si hay problemas de resolución de nombre de host
+    instance-id: "\${spring.application.name}:\${random.uuid}" # Identificador único en Eureka
+    statusPageUrlPath: "/actuator/info"
+    healthCheckUrlPath: "/actuator/health"


### PR DESCRIPTION
…config

- Modified api-config-server's application.yml to use the native profile, pointing to the local './config-repo/' for configurations. This simplifies local development and ensures the Config Server can start without external SSH key dependencies.
- Added 'config-repo/personal-service.yml' with example properties to demonstrate specific configuration loading for personal-service. This will allow personal-service to receive centralized configuration beyond the global application.yml.
- Ensured Eureka client configuration is present in the new personal-service.yml and updated api-config-server.yml for clarity.

These changes address the core request to ensure personal-service can connect to and be configured by the Config Server in a local environment.