### PR TITLE
Fix: Correct YAML parsing errors and confirm native profile path

### DIFF
--- a/api-config-server/src/main/resources/application.yml
+++ b/api-config-server/src/main/resources/application.yml
@@ -5,13 +5,7 @@ spring:
     config:
       server:
         native:
-          search-locations: file:./config-repo/ # Apunta al config-repo local
-          # La configuración de Git anterior se elimina/comenta
-          # git:
-          #   uri: git@github.com:MartinMSalas/config-server-personal-admin.git
-          #   private-key: file:/home/m/.ssh/id_rsa
-          #   default-label: master
-          #   ignore-local-ssh-settings: false
+          search-locations: file:./config-repo/ # Asumiendo ejecución desde la raíz del proyecto donde está config-repo
   profiles:
     active: native # Asegurarse de que el perfil native esté activo
 
@@ -39,12 +33,13 @@ info:
 eureka:
   instance:
     instance-id: MMSTechnology-Personal-Admin:${spring.application.name}:${server.port}
-    statusPageUrlPath: http://localhost:8888/actuator/info
-    healthCheckUrlPath: http://localhost:8888/actuator/health
+    statusPageUrlPath: http://localhost:8888/actuator/info # Usar localhost para URLs de instancia si Eureka está en localhost
+    healthCheckUrlPath: http://localhost:8888/actuator/health # Usar localhost
     # Preferir la IP para el registro en Eureka si hay problemas con hostname
     # prefer-ip-address: true
+    # hostname: localhost # Fijar el hostname si es necesario
   client:
     register-with-eureka: true
-    fetch-registry: true # Necesario para que el config server sepa de otros servicios si es necesario
+    fetch-registry: true
     serviceUrl:
       defaultZone: http://localhost:8761/eureka/

--- a/config-repo/application.yml
+++ b/config-repo/application.yml
@@ -36,7 +36,7 @@ management:
 # To see trace IDs in logs (auto-configured with compatible logging starters like Logback)
 logging:
   pattern:
-    level: "%5p [\${spring.application.name:unknown-service},%X{traceId:-},%X{spanId:-}]" # Example for console logging
+    level: '%5p [${spring.application.name:unknown-service},%X{traceId:-},%X{spanId:-}]' # Example for console logging
 
 # --- Security Configuration (Keycloak Integration Placeholder) ---
 spring:

--- a/config-repo/personal-service.yml
+++ b/config-repo/personal-service.yml
@@ -2,9 +2,9 @@ server:
   port: 7070 # Puerto específico para personal-service desde config-server
 
 personal:
-  greeting: "Hola desde la configuración remota para Personal Service!"
+  greeting: 'Hola desde la configuración remota para Personal Service!' # Usar comillas simples
   instance:
-    id: "${spring.application.name}:${random.uuid}"
+    id: '${spring.application.name}:${random.uuid}' # Usar comillas simples
 
 # Ejemplo de cómo se podrían heredar y usar propiedades de application.yml
 # Si global.message está en application.yml, estará disponible aquí también.
@@ -25,11 +25,11 @@ management:
 
 info:
   app:
-    name: "\${spring.application.name}" # Usar el nombre de la aplicación
+    name: '${spring.application.name}' # Usar comillas simples
     description: "Configuración específica para Personal Service cargada desde Config Server"
-    instanceId: "\${personal.instance.id}"
-    remoteConfigProperty: "\${personal.greeting}"
-    globalMessageFromRemote: "\${global.message:Global message not found}" # Muestra global.message o un default
+    instanceId: '${personal.instance.id}' # Usar comillas simples
+    remoteConfigProperty: '${personal.greeting}' # Usar comillas simples
+    globalMessageFromRemote: '${global.message:Global message not found}' # Usar comillas simples
 
 # Para asegurar que personal-service se registra en Eureka
 eureka:
@@ -40,6 +40,6 @@ eureka:
       defaultZone: http://localhost:8761/eureka/ # Asegurar que esto esté aquí o en application.yml
   instance:
     # prefer-ip-address: true # Considerar si hay problemas de resolución de nombre de host
-    instance-id: "\${spring.application.name}:\${random.uuid}" # Identificador único en Eureka
+    instance-id: '${spring.application.name}:${random.uuid}' # Usar comillas simples
     statusPageUrlPath: "/actuator/info"
     healthCheckUrlPath: "/actuator/health"


### PR DESCRIPTION
- Corrected YAML syntax in config-repo/application.yml and config-repo/personal-service.yml by replacing double quotes with single quotes around values containing Spring placeholders (e.g., ${...}). This resolves the SnakeYAML ScannerException that prevented the Config Server from parsing these files.
- Ensured api-config-server's application.yml uses native profile with search-locations set to file:./config-repo/, based on log analysis of the working directory.

These changes should allow the Config Server to start correctly and serve configurations to client applications, including personal-service.